### PR TITLE
Add readme, license, documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "vk-parse"
 version = "0.1.0"
 authors = ["krolli <kroslakma@gmail.com>"]
+description = "Vulkan specification parser"
+readme = "README.md"
+license = "Apache-2.0/MIT"
+keywords = ["vulkan", "parser"]
+categories = ["parser-implementations", "rendering::graphics-api"]
 
 [dependencies]
 vkxml = {git = "https://github.com/terrybrashaw/vkxml"}
@@ -14,3 +19,7 @@ serde_derive = "*"
 
 [dev-dependencies]
 reqwest = "*"
+
+[badges]
+is-it-maintained-issue-resolution = { repository = "https://github.com/krolli/vk-parse/" }
+is-it-maintained-open-issues = { repository = "https://github.com/krolli/vk-parse/" }

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This crate consists of a
 ```sh
 cargo run --release 'vulkan.xml' -o 'generated-file.ron'
 ```
+
+## License
+
+This software is dual-licensed under Apache-2.0/MIT, same as Rust itself.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# vk-parse
+
+`vk-parse` is a Rust crate which parses the Vulkan API registry XML and converts it to a Rust representation.
+
+This crate consists of a
+
+- library which does the actual parsing of the Vulkan registry
+- command line tool which parses Vulkan XML and serializes it to a [RON](https://github.com/ron-rs/ron) file.
+
+## Command Line Tool usage
+
+```sh
+cargo run --release 'vulkan.xml' -o 'generated-file.ron'
+```

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -35,6 +35,9 @@ fn new_field() -> vkxml::Field {
     }
 }
 
+/// Parses an file which must be the Vulkan registry XML in its standard format.
+///
+/// Returns a Rust representation of the registry.
 pub fn parse_file_as_vkxml(path: &std::path::Path) -> vkxml::Registry {
     let file = std::io::BufReader::new(std::fs::File::open(path).unwrap());
     let parser = xml::reader::ParserConfig::new().create_reader(file);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! This crate parses the Vulkan XML registry into a Rust object.
+//!
+//! The entry point into this library is `parse_file_as_vkxml`, which will
+//! return a `Registry` object. This object contains all the information contained
+//! in the Vulkan API registry.
+
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -123,6 +123,8 @@ macro_rules! match_elements_combine_text {
 }
 
 //--------------------------------------------------------------------------------------------------
+
+/// Parses the Vulkan XML file into a Rust object.
 pub fn parse_file(path: &std::path::Path) -> Registry {
     let file = std::io::BufReader::new(std::fs::File::open(path).unwrap());
     let parser = xml::reader::ParserConfig::new().create_reader(file);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,25 +1,38 @@
+/// Rust structure representing the Vulkan registry.
+///
+/// The registry contains all the information contained in a certain version
+/// of the Vulkan specification, stored within a programmer-accessible format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Registry(pub Vec<RegistryItem>);
 
+/// An element of the Vulkan registry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RegistryItem {
+    /// Comments are human-readable strings which contain registry meta-data.
     Comment(String),
+    /// IDs of all known Vulkan vendors.
     VendorIds {
         comment: Option<String>,
         items: Vec<VendorId>,
     },
+    /// List of supported Vulkan platforms.
     Platforms {
         comment: Option<String>,
         items: Vec<Platform>,
     },
+    /// Known extension tags.
     Tags {
         comment: Option<String>,
         items: Vec<Tag>,
     },
+    /// Type definitions.
+    ///
+    /// Unlike OpenGL, Vulkan is a strongly-typed API.
     Types {
         comment: Option<String>,
         items: Vec<TypeItem>,
     },
+    /// Enum definitions.
     Enums {
         name: Option<String>,
         kind: Option<String>,
@@ -29,10 +42,12 @@ pub enum RegistryItem {
         comment: Option<String>,
         items: Vec<EnumsItem>,
     },
+    /// Commands are the Vulkan API's name for functions.
     Commands {
         comment: Option<String>,
         items: Vec<Command>,
     },
+    /// Feature level of the API, such as Vulkan 1.0 or 1.1
     Feature {
         api: String,
         name: String,
@@ -41,33 +56,57 @@ pub enum RegistryItem {
         comment: Option<String>,
         items: Vec<ExtensionItem>,
     },
+    /// Container for all published Vulkan specification extensions.
     Extensions {
         comment: Option<String>,
         items: Vec<Extension>,
     },
 }
 
+/// Unique identifier for a Vulkan vendor.
+///
+/// Note: in newer versions of the Vulkan spec, this tag is not used,
+/// instead it has been replaced by the `VKVendorId` enum.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VendorId {
+    /// Name of the vendor.
     pub name: String,
+    /// Human-readable description.
     pub comment: Option<String>,
+    /// The unique ID.
     pub id: u32,
 }
 
+/// A platform refers to a windowing system which Vulkan can use.
+///
+/// Most operating systems will have only one corresponding platform,
+/// but Linux has multiple (XCB, Wayland, etc.)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Platform {
+    /// Short identifier.
     pub name: String,
+    /// Human readable description of the platform.
     pub comment: Option<String>,
+    /// C macro name which is used to guard platform-specific definitions.
     pub protect: String,
 }
 
+/// Tags are the little suffixes attached to extension names or items, indicating the author.
+///
+/// Some examples:
+/// - KHR for Khronos extensions
+/// - EXT for multi-vendor extensions
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Tag {
+    /// The name of the tag, e.g. "KHR".
     pub name: String,
+    /// Author of the extensions associated with the tag, e.g. "Khronos".
     pub author: String,
+    /// Contact information for the extension author(s).
     pub contact: String,
 }
 
+/// An item making up a type definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TypeItem {
     Type {
@@ -85,6 +124,7 @@ pub enum TypeItem {
     Comment(String),
 }
 
+/// The contents of a type definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TypeContents {
     Code {
@@ -102,9 +142,12 @@ pub enum TypeCodeMarkup {
     ApiEntry(String),
 }
 
+/// A member of a type definition, i.e. a struct member.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TypeMember {
+    /// Human-readable comment.
     Comment(String),
+    /// A structure field definition.
     Definition {
         len: Option<String>,
         altlen: Option<String>,
@@ -126,12 +169,15 @@ pub enum TypeMemberMarkup {
     Comment(String),
 }
 
+/// A command is just a Vulkan function.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Command {
+    /// Indicates this function is an alias for another one.
     Alias {
         name: String,
         alias: String,
     },
+    /// Defines a new Vulkan function.
     Definition {
         queues: Option<String>,
         successcodes: Option<String>,
@@ -150,46 +196,69 @@ pub enum Command {
     },
 }
 
+/// Parameter for this Vulkan function.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandParam {
+    /// The expression which indicates the length of this array.
     pub len: Option<String>,
+    /// Alternate description of the length of this parameter.
     pub altlen: Option<String>,
+    /// Whether tihs parameter must be externally synchronised by the app.
     pub externsync: Option<String>,
+    /// Whether this parameter must have a non-null value.
     pub optional: Option<String>,
+    /// Disables automatic validity language being generated for this item.
     pub noautovalidity: Option<String>,
 
+    /// The definition of this parameter.
     pub definition: NameWithType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Extension {
+    /// Name of the extension.
     pub name: String,
+    /// Human-readable description.
     pub comment: Option<String>,
+    /// The unique index of this extension.
     pub number: Option<i64>,
     pub protect: Option<String>,
+    /// Which platform it works with, if any.
     pub platform: Option<String>,
+    /// Tag name of the author.
     pub author: Option<String>,
+    /// Contact information for extension author(s).
     pub contact: Option<String>,
+    /// The level at which the extension applies (instance / device).
     pub ext_type: Option<String>,
     pub requires: Option<String>,
     pub requires_core: Option<String>,
     pub supported: Option<String>, // mk:TODO StringGroup?
     pub deprecatedby: Option<String>,
+    /// Whether this extension was promoted to core, and in which version.
     pub promotedto: Option<String>,
     pub obsoletedby: Option<String>,
+    /// The items which make up this extension.
     pub items: Vec<ExtensionItem>,
 }
 
+/// A part of an extension declaration.
+///
+/// Extensions either include functionality from the spec, or remove some functionality.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExtensionItem {
+    /// Indicates the items which this extension requires to work.
     Require {
         api: Option<String>,
         profile: Option<String>,
+        /// The extension which provides these required items, if any.
         extension: Option<String>,
         feature: Option<String>,
         comment: Option<String>,
+        /// The items which form this require block.
         items: Vec<InterfaceItem>,
     },
+    /// Indicates the items this extension removes.
     Remove {
         api: Option<String>,
         profile: Option<String>,
@@ -198,6 +267,9 @@ pub enum ExtensionItem {
     },
 }
 
+/// An interface item is a function or an enum which makes up a Vulkan interface.
+///
+/// This structure is used by extensions to express dependencies or include functionality.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum InterfaceItem {
     Comment(String),
@@ -212,18 +284,27 @@ pub enum InterfaceItem {
     },
 }
 
+/// An item which forms an enum.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EnumsItem {
+    /// Actual named enum.
     Enum(Enum),
+    /// An unused range of enum values.
     Unused {
+        /// Beginning of the range.
         start: i64,
+        /// Ending value of the range, if any.
         end: Option<i64>,
+        /// Vendor who reserved this range.
         vendor: Option<String>,
+        /// Human-readable description.
         comment: Option<String>,
     },
+    /// Human-readable comment.
     Comment(String),
 }
 
+/// An enum specifier, which assigns a value to the enum.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EnumSpec {
     Alias {
@@ -236,20 +317,29 @@ pub enum EnumSpec {
         extnumber: Option<i64>,
         dir: bool,
     },
+    /// Indicates an enum which is a bit flag.
     Bitpos {
+        /// The bit to be set.
         bitpos: i64,
+        /// Which structure this enum extends.
         extends: Option<String>,
     },
+    /// An enum value.
     Value {
+        /// Hard coded value for an enum.
         value: String, // rnc says this is an Integer, but validates it as text, and that's what it sometimes really is.
+        /// Which structure this enum extends.
         extends: Option<String>,
     },
     None,
 }
 
+/// An item of an enumeration type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Enum {
+    /// Name of this enum.
     pub name: String,
+    /// Human-readable description.
     pub comment: Option<String>,
     pub type_suffix: Option<String>,
     pub api: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -203,7 +203,7 @@ pub struct CommandParam {
     pub len: Option<String>,
     /// Alternate description of the length of this parameter.
     pub altlen: Option<String>,
-    /// Whether tihs parameter must be externally synchronised by the app.
+    /// Whether this parameter must be externally synchronised by the app.
     pub externsync: Option<String>,
     /// Whether this parameter must have a non-null value.
     pub optional: Option<String>,


### PR DESCRIPTION
This pull request adds some documentation for the crate:

- a README which describes the project.
- suggests dual-licensing this crate under Apache-2.0/MIT, same licensing Rust uses, as well as most other crates.
- adds some documentation to the public API.
- updates the `Cargo.toml` with this information, in anticipation of publishing to crates.io

Fixes #7.
Fixes #8, since it now documents that `VendorId` is not used in newer versions of the registry.