### PR TITLE
Parse and provide bitwidth attribute on <enums> element

### DIFF
--- a/vk-parse/src/parse.rs
+++ b/vk-parse/src/parse.rs
@@ -267,14 +267,16 @@ fn parse_registry<R: Read>(ctx: &mut ParseCtx<R>) -> Result<Registry, FatalError
             let mut end = None;
             let mut vendor = None;
             let mut comment = None;
+            let mut bitwidth = None;
             let mut children = Vec::new();
             match_attributes!{ctx, a in attributes,
-                "name"    => name    = Some(a.value),
-                "type"    => kind    = Some(a.value),
-                "start"   => start   = Some(a.value),
-                "end"     => end     = Some(a.value),
-                "vendor"  => vendor  = Some(a.value),
-                "comment" => comment = Some(a.value)
+                "name"     => name     = Some(a.value),
+                "type"     => kind     = Some(a.value),
+                "start"    => start    = Some(a.value),
+                "end"      => end      = Some(a.value),
+                "vendor"   => vendor   = Some(a.value),
+                "comment"  => comment  = Some(a.value),
+                "bitwidth" => bitwidth = Some(a.value)
             }
             match_elements!{ctx, attributes,
                 "enum" => if let Some(v) = parse_enum(ctx, attributes) {
@@ -288,8 +290,9 @@ fn parse_registry<R: Read>(ctx: &mut ParseCtx<R>) -> Result<Registry, FatalError
 
             let start = start.and_then(|val| parse_integer(ctx, &val));
             let end = end.and_then(|val| parse_integer(ctx, &val));
+            let bitwidth = bitwidth.and_then(|val| parse_integer(ctx, &val)).map(|val| val as u32);
 
-            registry.0.push(RegistryChild::Enums(Enums{ name, kind, start, end, vendor, comment, children }));
+            registry.0.push(RegistryChild::Enums(Enums{ name, kind, start, end, vendor, comment, children, bitwidth }));
         },
         "commands" => {
             let mut comment = None;

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -405,6 +405,12 @@ pub struct Enums {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub children: Vec<EnumsChild>,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub bitwidth: Option<u32>,
 }
 
 /// An item which forms an enum.


### PR DESCRIPTION
This attribute specifies - together with a typedef to VkFlags(64) - the size of an enum. VK_KHR_synchronization2 introduces larger
bitflags/bitmasks with more than 32 bits in use. These bitmasks have bitwidth set to 64, while the default for enums is assumed to be 32 bit.

---

### Future tasks

- [ ] Perhaps this option should be an enum for 32- and 64-bit variants, defaulting to 32-bit? That's less expressive though, in case future alterations are added (though very unlikely).
- [ ] Add support for remaining new attributes, so that one of the newer `vk.xml`s (`.172`) can be tested in the CI.

If I may ask: Why isn't this crate deserializing to structures directly with Serde, followed by optional conversion and error checking? The manual approach with `match_attributes!` is pretty verbose. Or was that not possible/not expressive enough back in the day?