### PR TITLE
Allow comparison of `Error`s

### DIFF
--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -17,7 +17,7 @@ impl From<std::io::Error> for FatalError {
 /// which it occurs. For example, unrecognized attribute will simply be skipped
 /// without affecting anything around it, while unrecognized element will have
 /// all of its contents skipped.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
     UnexpectedElement {


### PR DESCRIPTION
I have an application, where I want to [deduplicate](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.dedup) the `Vec<Error>` returned by [`parse_file()`](https://docs.rs/vk-parse/0.6.0/vk_parse/fn.parse_file.html). This requires `PartialEq` of the type, which is added here.