### PR TITLE
Strongly-typed parsed data structures, no longer stringly-typed

### DIFF
--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -13,3 +13,4 @@ serde_derive = "^1.0.75"
 vk-parse = { path = "../vk-parse", features = ["serialize", "vkxml-convert"] }
 vkxml = "^0.3"
 xml-rs = "^0.8"
+paste = "1.0"

--- a/ci/tests/test.rs
+++ b/ci/tests/test.rs
@@ -9,6 +9,8 @@ extern crate xml;
 
 const URL_REPO: &str = "https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs";
 const URL_MAIN: &str = "https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs/main/xml/vk.xml";
+const URL_MAIN_VIDEO: &str =
+    "https://raw.githubusercontent.com/KhronosGroup/Vulkan-Docs/main/xml/video.xml";
 
 fn download<T: std::io::Write>(dst: &mut T, url: &str) {
     let resp = minreq::get(url)
@@ -66,6 +68,28 @@ fn test_main() {
     use std::io::Cursor;
     let mut buf = Cursor::new(vec![0; 15]);
     download(&mut buf, URL_MAIN);
+    buf.set_position(0);
+
+    match vk_parse::parse_stream(buf.clone()) {
+        Ok((_reg, errors)) => {
+            if !errors.is_empty() {
+                panic!("{:?}", errors);
+            }
+        }
+        Err(fatal_error) => panic!("{:?}", fatal_error),
+    }
+
+    match vk_parse::parse_stream_as_vkxml(buf) {
+        Ok(_) => (),
+        Err(fatal_error) => panic!("{:?}", fatal_error),
+    }
+}
+
+#[test]
+fn test_main_video() {
+    use std::io::Cursor;
+    let mut buf = Cursor::new(vec![0; 15]);
+    download(&mut buf, URL_MAIN_VIDEO);
     buf.set_position(0);
 
     match vk_parse::parse_stream(buf.clone()) {

--- a/ci/tests/test.rs
+++ b/ci/tests/test.rs
@@ -15,7 +15,7 @@ const URL_MAIN_VIDEO: &str =
 fn download<T: std::io::Write>(dst: &mut T, url: &str) {
     let resp = minreq::get(url)
         .send()
-        .expect(&format!("Failed to GET resource: {:?}", url));
+        .unwrap_or_else(|_| panic!("Failed to GET resource: {:?}", url));
 
     let is_success = 200 <= resp.status_code && resp.status_code < 300;
     if !is_success {

--- a/ci/tests/test.rs
+++ b/ci/tests/test.rs
@@ -302,3 +302,6 @@ test_version! {1, 3, 222, "/xml"}
 test_version! {1, 3, 223, "/xml"}
 test_version! {1, 3, 224, "/xml"}
 test_version! {1, 3, 225, "/xml"}
+test_version! {1, 3, 226, "/xml"}
+test_version! {1, 3, 227, "/xml"}
+test_version! {1, 3, 228, "/xml"}

--- a/ci/tests/test.rs
+++ b/ci/tests/test.rs
@@ -60,7 +60,7 @@ macro_rules! test_version {
             #[test]
             fn [< test_v $major _ $minor _ $patch >] () {
                 parsing_test($major, $minor, $patch, $url_suffix);
-            }    
+            }
         }
     };
 }

--- a/ci/tests/test.rs
+++ b/ci/tests/test.rs
@@ -55,10 +55,12 @@ fn parsing_test(major: u32, minor: u32, patch: u32, url_suffix: &str) {
 }
 
 macro_rules! test_version {
-    ($test_name:ident, $major:expr, $minor:expr, $patch:expr, $url_suffix:expr) => {
-        #[test]
-        fn $test_name() {
-            parsing_test($major, $minor, $patch, $url_suffix);
+    ($major:expr, $minor:expr, $patch:expr, $url_suffix:expr) => {
+        paste::paste! {
+            #[test]
+            fn [< test_v $major _ $minor _ $patch >] () {
+                parsing_test($major, $minor, $patch, $url_suffix);
+            }    
         }
     };
 }
@@ -107,174 +109,196 @@ fn test_main_video() {
     }
 }
 
-test_version! {test_v1_0_33, 1, 0, 33, "-core/src/spec"}
-test_version! {test_v1_0_34, 1, 0, 34, "-core/src/spec"}
-test_version! {test_v1_0_35, 1, 0, 35, "-core/src/spec"}
-test_version! {test_v1_0_36, 1, 0, 36, "-core/src/spec"}
-// test_version!{test_v1_1_37, 1, 0, 37, "-core/src/spec"} // no tag for v1.0.37
-test_version! {test_v1_0_38, 1, 0, 38, "-core/src/spec"}
-test_version! {test_v1_0_39, 1, 0, 39, "-core/src/spec"}
-test_version! {test_v1_0_40, 1, 0, 40, "-core/src/spec"}
-test_version! {test_v1_0_41, 1, 0, 41, "-core/src/spec"}
-test_version! {test_v1_0_42, 1, 0, 42, "-core/src/spec"}
-test_version! {test_v1_0_43, 1, 0, 43, "-core/src/spec"}
-test_version! {test_v1_0_44, 1, 0, 44, "-core/src/spec"}
-test_version! {test_v1_0_45, 1, 0, 45, "-core/src/spec"}
-test_version! {test_v1_0_46, 1, 0, 46, "-core/src/spec"}
-test_version! {test_v1_0_47, 1, 0, 47, "-core/src/spec"}
-test_version! {test_v1_0_48, 1, 0, 48, "-core/src/spec"}
-test_version! {test_v1_0_49, 1, 0, 49, "-core/src/spec"}
-test_version! {test_v1_0_50, 1, 0, 50, "-core/src/spec"}
-test_version! {test_v1_0_51, 1, 0, 51, "-core/src/spec"}
-// test_version!{test_v1_0_52, 1, 0, 52, "-core/src/spec"} // no tag for v1.0.52
-test_version! {test_v1_0_53, 1, 0, 53, "-core/src/spec"}
-test_version! {test_v1_0_54, 1, 0, 54, "-core/src/spec"}
-test_version! {test_v1_0_55, 1, 0, 55, "-core/src/spec"}
-test_version! {test_v1_0_56, 1, 0, 56, "-core/src/spec"}
-test_version! {test_v1_0_57, 1, 0, 57, "-core/src/spec"}
-test_version! {test_v1_0_58, 1, 0, 58, "-core/src/spec"}
-test_version! {test_v1_0_59, 1, 0, 59, "-core/src/spec"}
-test_version! {test_v1_0_60, 1, 0, 60, "-core/src/spec"}
-test_version! {test_v1_0_61, 1, 0, 61, "-core/src/spec"}
-test_version! {test_v1_0_62, 1, 0, 62, "-core/src/spec"}
-test_version! {test_v1_0_63, 1, 0, 63, "-core/src/spec"}
-test_version! {test_v1_0_64, 1, 0, 64, "-core/src/spec"}
-test_version! {test_v1_0_65, 1, 0, 65, "-core/src/spec"}
-test_version! {test_v1_0_66, 1, 0, 66, "-core/src/spec"}
-test_version! {test_v1_0_67, 1, 0, 67, "-core/src/spec"}
-test_version! {test_v1_0_68, 1, 0, 68, "-core/src/spec"}
-test_version! {test_v1_0_69, 1, 0, 69, "-core/src/spec"}
-test_version! {test_v1_1_70, 1, 1, 70, "/src/spec"}
-test_version! {test_v1_1_71, 1, 1, 71, "/src/spec"}
-test_version! {test_v1_1_72, 1, 1, 72, "/xml"}
-test_version! {test_v1_1_73, 1, 1, 73, "/xml"}
-test_version! {test_v1_1_74, 1, 1, 74, "/xml"}
-test_version! {test_v1_1_75, 1, 1, 75, "/xml"}
-test_version! {test_v1_1_76, 1, 1, 76, "/xml"}
-test_version! {test_v1_1_77, 1, 1, 77, "/xml"}
-test_version! {test_v1_1_78, 1, 1, 78, "/xml"}
-test_version! {test_v1_1_79, 1, 1, 79, "/xml"}
-test_version! {test_v1_1_80, 1, 1, 80, "/xml"}
-test_version! {test_v1_1_81, 1, 1, 81, "/xml"}
-test_version! {test_v1_1_82, 1, 1, 82, "/xml"}
-test_version! {test_v1_1_83, 1, 1, 83, "/xml"}
-test_version! {test_v1_1_84, 1, 1, 84, "/xml"}
-test_version! {test_v1_1_85, 1, 1, 85, "/xml"}
-test_version! {test_v1_1_86, 1, 1, 86, "/xml"}
-test_version! {test_v1_1_87, 1, 1, 87, "/xml"}
-test_version! {test_v1_1_88, 1, 1, 88, "/xml"}
-test_version! {test_v1_1_89, 1, 1, 89, "/xml"}
-test_version! {test_v1_1_90, 1, 1, 90, "/xml"}
-test_version! {test_v1_1_91, 1, 1, 91, "/xml"}
-test_version! {test_v1_1_92, 1, 1, 92, "/xml"}
-test_version! {test_v1_1_93, 1, 1, 93, "/xml"}
-test_version! {test_v1_1_94, 1, 1, 94, "/xml"}
-test_version! {test_v1_1_95, 1, 1, 95, "/xml"}
-test_version! {test_v1_1_96, 1, 1, 96, "/xml"}
-test_version! {test_v1_1_97, 1, 1, 97, "/xml"}
-test_version! {test_v1_1_98, 1, 1, 98, "/xml"}
-test_version! {test_v1_1_99, 1, 1, 99, "/xml"}
-test_version! {test_v1_1_100, 1, 1, 100, "/xml"}
-test_version! {test_v1_1_101, 1, 1, 101, "/xml"}
-test_version! {test_v1_1_102, 1, 1, 102, "/xml"}
-test_version! {test_v1_1_103, 1, 1, 103, "/xml"}
-test_version! {test_v1_1_104, 1, 1, 104, "/xml"}
-test_version! {test_v1_1_105, 1, 1, 105, "/xml"}
-test_version! {test_v1_1_106, 1, 1, 106, "/xml"}
-test_version! {test_v1_1_107, 1, 1, 107, "/xml"}
-test_version! {test_v1_1_108, 1, 1, 108, "/xml"}
-test_version! {test_v1_1_109, 1, 1, 109, "/xml"}
-test_version! {test_v1_1_110, 1, 1, 110, "/xml"}
-test_version! {test_v1_1_111, 1, 1, 111, "/xml"}
-test_version! {test_v1_1_112, 1, 1, 112, "/xml"}
-test_version! {test_v1_1_113, 1, 1, 113, "/xml"}
-test_version! {test_v1_1_114, 1, 1, 114, "/xml"}
-test_version! {test_v1_1_115, 1, 1, 115, "/xml"}
-test_version! {test_v1_1_116, 1, 1, 116, "/xml"}
-test_version! {test_v1_1_117, 1, 1, 117, "/xml"}
-test_version! {test_v1_1_118, 1, 1, 118, "/xml"}
-test_version! {test_v1_1_119, 1, 1, 119, "/xml"}
-test_version! {test_v1_1_120, 1, 1, 120, "/xml"}
-test_version! {test_v1_1_121, 1, 1, 121, "/xml"}
-test_version! {test_v1_1_122, 1, 1, 122, "/xml"}
-test_version! {test_v1_1_123, 1, 1, 123, "/xml"}
-test_version! {test_v1_1_124, 1, 1, 124, "/xml"}
-test_version! {test_v1_1_125, 1, 1, 125, "/xml"}
-test_version! {test_v1_1_126, 1, 1, 126, "/xml"}
-test_version! {test_v1_1_127, 1, 1, 127, "/xml"}
-test_version! {test_v1_1_128, 1, 1, 128, "/xml"}
-test_version! {test_v1_1_129, 1, 1, 129, "/xml"}
-test_version! {test_v1_1_130, 1, 1, 130, "/xml"}
-test_version! {test_v1_2_131, 1, 2, 131, "/xml"}
-test_version! {test_v1_2_132, 1, 2, 132, "/xml"}
-test_version! {test_v1_2_133, 1, 2, 133, "/xml"}
-test_version! {test_v1_2_134, 1, 2, 134, "/xml"}
-test_version! {test_v1_2_135, 1, 2, 135, "/xml"}
-test_version! {test_v1_2_136, 1, 2, 136, "/xml"}
-test_version! {test_v1_2_137, 1, 2, 137, "/xml"}
-test_version! {test_v1_2_138, 1, 2, 138, "/xml"}
-test_version! {test_v1_2_139, 1, 2, 139, "/xml"}
-test_version! {test_v1_2_140, 1, 2, 140, "/xml"}
-test_version! {test_v1_2_141, 1, 2, 141, "/xml"}
-test_version! {test_v1_2_142, 1, 2, 142, "/xml"}
-test_version! {test_v1_2_143, 1, 2, 143, "/xml"}
-test_version! {test_v1_2_144, 1, 2, 144, "/xml"}
-test_version! {test_v1_2_145, 1, 2, 145, "/xml"}
-test_version! {test_v1_2_146, 1, 2, 146, "/xml"}
-test_version! {test_v1_2_147, 1, 2, 147, "/xml"}
-test_version! {test_v1_2_148, 1, 2, 148, "/xml"}
-test_version! {test_v1_2_149, 1, 2, 149, "/xml"}
-test_version! {test_v1_2_150, 1, 2, 150, "/xml"}
-test_version! {test_v1_2_151, 1, 2, 151, "/xml"}
-test_version! {test_v1_2_152, 1, 2, 152, "/xml"}
-test_version! {test_v1_2_153, 1, 2, 153, "/xml"}
-test_version! {test_v1_2_154, 1, 2, 154, "/xml"}
-test_version! {test_v1_2_155, 1, 2, 155, "/xml"}
-test_version! {test_v1_2_156, 1, 2, 156, "/xml"}
-test_version! {test_v1_2_157, 1, 2, 157, "/xml"}
-test_version! {test_v1_2_158, 1, 2, 158, "/xml"}
-test_version! {test_v1_2_159, 1, 2, 159, "/xml"}
-test_version! {test_v1_2_160, 1, 2, 160, "/xml"}
-test_version! {test_v1_2_161, 1, 2, 161, "/xml"}
-test_version! {test_v1_2_162, 1, 2, 162, "/xml"}
-test_version! {test_v1_2_163, 1, 2, 163, "/xml"}
-test_version! {test_v1_2_164, 1, 2, 164, "/xml"}
-test_version! {test_v1_2_165, 1, 2, 165, "/xml"}
-test_version! {test_v1_2_166, 1, 2, 166, "/xml"}
-test_version! {test_v1_2_167, 1, 2, 167, "/xml"}
-test_version! {test_v1_2_168, 1, 2, 168, "/xml"}
-test_version! {test_v1_2_169, 1, 2, 169, "/xml"}
-test_version! {test_v1_2_170, 1, 2, 170, "/xml"}
-test_version! {test_v1_2_171, 1, 2, 171, "/xml"}
-test_version! {test_v1_2_172, 1, 2, 172, "/xml"}
-test_version! {test_v1_2_173, 1, 2, 173, "/xml"}
-test_version! {test_v1_2_174, 1, 2, 174, "/xml"}
-test_version! {test_v1_2_175, 1, 2, 175, "/xml"}
-test_version! {test_v1_2_176, 1, 2, 176, "/xml"}
-test_version! {test_v1_2_177, 1, 2, 177, "/xml"}
-test_version! {test_v1_2_178, 1, 2, 178, "/xml"}
-test_version! {test_v1_2_179, 1, 2, 179, "/xml"}
-test_version! {test_v1_2_180, 1, 2, 180, "/xml"}
-test_version! {test_v1_2_181, 1, 2, 181, "/xml"}
-test_version! {test_v1_2_182, 1, 2, 182, "/xml"}
-test_version! {test_v1_2_183, 1, 2, 183, "/xml"}
-test_version! {test_v1_2_184, 1, 2, 184, "/xml"}
-test_version! {test_v1_2_185, 1, 2, 185, "/xml"}
-test_version! {test_v1_2_186, 1, 2, 186, "/xml"}
-test_version! {test_v1_2_187, 1, 2, 187, "/xml"}
-test_version! {test_v1_2_188, 1, 2, 188, "/xml"}
-test_version! {test_v1_2_189, 1, 2, 189, "/xml"}
-test_version! {test_v1_2_190, 1, 2, 190, "/xml"}
-test_version! {test_v1_2_191, 1, 2, 191, "/xml"}
-test_version! {test_v1_2_192, 1, 2, 192, "/xml"}
-test_version! {test_v1_2_193, 1, 2, 193, "/xml"}
-test_version! {test_v1_2_194, 1, 2, 194, "/xml"}
-test_version! {test_v1_2_195, 1, 2, 195, "/xml"}
-test_version! {test_v1_2_196, 1, 2, 196, "/xml"}
-test_version! {test_v1_2_197, 1, 2, 197, "/xml"}
-test_version! {test_v1_2_198, 1, 2, 198, "/xml"}
-test_version! {test_v1_2_199, 1, 2, 199, "/xml"}
-test_version! {test_v1_2_200, 1, 2, 200, "/xml"}
-test_version! {test_v1_2_201, 1, 2, 201, "/xml"}
-test_version! {test_v1_2_202, 1, 2, 202, "/xml"}
-test_version! {test_v1_2_203, 1, 2, 203, "/xml"}
+test_version! {1, 0, 33, "-core/src/spec"}
+test_version! {1, 0, 34, "-core/src/spec"}
+test_version! {1, 0, 35, "-core/src/spec"}
+test_version! {1, 0, 36, "-core/src/spec"}
+// test_version!{1, 0, 37, "-core/src/spec"} // no tag for v1.0.37
+test_version! {1, 0, 38, "-core/src/spec"}
+test_version! {1, 0, 39, "-core/src/spec"}
+test_version! {1, 0, 40, "-core/src/spec"}
+test_version! {1, 0, 41, "-core/src/spec"}
+test_version! {1, 0, 42, "-core/src/spec"}
+test_version! {1, 0, 43, "-core/src/spec"}
+test_version! {1, 0, 44, "-core/src/spec"}
+test_version! {1, 0, 45, "-core/src/spec"}
+test_version! {1, 0, 46, "-core/src/spec"}
+test_version! {1, 0, 47, "-core/src/spec"}
+test_version! {1, 0, 48, "-core/src/spec"}
+test_version! {1, 0, 49, "-core/src/spec"}
+test_version! {1, 0, 50, "-core/src/spec"}
+test_version! {1, 0, 51, "-core/src/spec"}
+// test_version!{1, 0, 52, "-core/src/spec"} // no tag for v1.0.52
+test_version! {1, 0, 53, "-core/src/spec"}
+test_version! {1, 0, 54, "-core/src/spec"}
+test_version! {1, 0, 55, "-core/src/spec"}
+test_version! {1, 0, 56, "-core/src/spec"}
+test_version! {1, 0, 57, "-core/src/spec"}
+test_version! {1, 0, 58, "-core/src/spec"}
+test_version! {1, 0, 59, "-core/src/spec"}
+test_version! {1, 0, 60, "-core/src/spec"}
+test_version! {1, 0, 61, "-core/src/spec"}
+test_version! {1, 0, 62, "-core/src/spec"}
+test_version! {1, 0, 63, "-core/src/spec"}
+test_version! {1, 0, 64, "-core/src/spec"}
+test_version! {1, 0, 65, "-core/src/spec"}
+test_version! {1, 0, 66, "-core/src/spec"}
+test_version! {1, 0, 67, "-core/src/spec"}
+test_version! {1, 0, 68, "-core/src/spec"}
+test_version! {1, 0, 69, "-core/src/spec"}
+test_version! {1, 1, 70, "/src/spec"}
+test_version! {1, 1, 71, "/src/spec"}
+test_version! {1, 1, 72, "/xml"}
+test_version! {1, 1, 73, "/xml"}
+test_version! {1, 1, 74, "/xml"}
+test_version! {1, 1, 75, "/xml"}
+test_version! {1, 1, 76, "/xml"}
+test_version! {1, 1, 77, "/xml"}
+test_version! {1, 1, 78, "/xml"}
+test_version! {1, 1, 79, "/xml"}
+test_version! {1, 1, 80, "/xml"}
+test_version! {1, 1, 81, "/xml"}
+test_version! {1, 1, 82, "/xml"}
+test_version! {1, 1, 83, "/xml"}
+test_version! {1, 1, 84, "/xml"}
+test_version! {1, 1, 85, "/xml"}
+test_version! {1, 1, 86, "/xml"}
+test_version! {1, 1, 87, "/xml"}
+test_version! {1, 1, 88, "/xml"}
+test_version! {1, 1, 89, "/xml"}
+test_version! {1, 1, 90, "/xml"}
+test_version! {1, 1, 91, "/xml"}
+test_version! {1, 1, 92, "/xml"}
+test_version! {1, 1, 93, "/xml"}
+test_version! {1, 1, 94, "/xml"}
+test_version! {1, 1, 95, "/xml"}
+test_version! {1, 1, 96, "/xml"}
+test_version! {1, 1, 97, "/xml"}
+test_version! {1, 1, 98, "/xml"}
+test_version! {1, 1, 99, "/xml"}
+test_version! {1, 1, 100, "/xml"}
+test_version! {1, 1, 101, "/xml"}
+test_version! {1, 1, 102, "/xml"}
+test_version! {1, 1, 103, "/xml"}
+test_version! {1, 1, 104, "/xml"}
+test_version! {1, 1, 105, "/xml"}
+test_version! {1, 1, 106, "/xml"}
+test_version! {1, 1, 107, "/xml"}
+test_version! {1, 1, 108, "/xml"}
+test_version! {1, 1, 109, "/xml"}
+test_version! {1, 1, 110, "/xml"}
+test_version! {1, 1, 111, "/xml"}
+test_version! {1, 1, 112, "/xml"}
+test_version! {1, 1, 113, "/xml"}
+test_version! {1, 1, 114, "/xml"}
+test_version! {1, 1, 115, "/xml"}
+test_version! {1, 1, 116, "/xml"}
+test_version! {1, 1, 117, "/xml"}
+test_version! {1, 1, 118, "/xml"}
+test_version! {1, 1, 119, "/xml"}
+test_version! {1, 1, 120, "/xml"}
+test_version! {1, 1, 121, "/xml"}
+test_version! {1, 1, 122, "/xml"}
+test_version! {1, 1, 123, "/xml"}
+test_version! {1, 1, 124, "/xml"}
+test_version! {1, 1, 125, "/xml"}
+test_version! {1, 1, 126, "/xml"}
+test_version! {1, 1, 127, "/xml"}
+test_version! {1, 1, 128, "/xml"}
+test_version! {1, 1, 129, "/xml"}
+test_version! {1, 1, 130, "/xml"}
+test_version! {1, 2, 131, "/xml"}
+test_version! {1, 2, 132, "/xml"}
+test_version! {1, 2, 133, "/xml"}
+test_version! {1, 2, 134, "/xml"}
+test_version! {1, 2, 135, "/xml"}
+test_version! {1, 2, 136, "/xml"}
+test_version! {1, 2, 137, "/xml"}
+test_version! {1, 2, 138, "/xml"}
+test_version! {1, 2, 139, "/xml"}
+test_version! {1, 2, 140, "/xml"}
+test_version! {1, 2, 141, "/xml"}
+test_version! {1, 2, 142, "/xml"}
+test_version! {1, 2, 143, "/xml"}
+test_version! {1, 2, 144, "/xml"}
+test_version! {1, 2, 145, "/xml"}
+test_version! {1, 2, 146, "/xml"}
+test_version! {1, 2, 147, "/xml"}
+test_version! {1, 2, 148, "/xml"}
+test_version! {1, 2, 149, "/xml"}
+test_version! {1, 2, 150, "/xml"}
+test_version! {1, 2, 151, "/xml"}
+test_version! {1, 2, 152, "/xml"}
+test_version! {1, 2, 153, "/xml"}
+test_version! {1, 2, 154, "/xml"}
+test_version! {1, 2, 155, "/xml"}
+test_version! {1, 2, 156, "/xml"}
+test_version! {1, 2, 157, "/xml"}
+test_version! {1, 2, 158, "/xml"}
+test_version! {1, 2, 159, "/xml"}
+test_version! {1, 2, 160, "/xml"}
+test_version! {1, 2, 161, "/xml"}
+test_version! {1, 2, 162, "/xml"}
+test_version! {1, 2, 163, "/xml"}
+test_version! {1, 2, 164, "/xml"}
+test_version! {1, 2, 165, "/xml"}
+test_version! {1, 2, 166, "/xml"}
+test_version! {1, 2, 167, "/xml"}
+test_version! {1, 2, 168, "/xml"}
+test_version! {1, 2, 169, "/xml"}
+test_version! {1, 2, 170, "/xml"}
+test_version! {1, 2, 171, "/xml"}
+test_version! {1, 2, 172, "/xml"}
+test_version! {1, 2, 173, "/xml"}
+test_version! {1, 2, 174, "/xml"}
+test_version! {1, 2, 175, "/xml"}
+test_version! {1, 2, 176, "/xml"}
+test_version! {1, 2, 177, "/xml"}
+test_version! {1, 2, 178, "/xml"}
+test_version! {1, 2, 179, "/xml"}
+test_version! {1, 2, 180, "/xml"}
+test_version! {1, 2, 181, "/xml"}
+test_version! {1, 2, 182, "/xml"}
+test_version! {1, 2, 183, "/xml"}
+test_version! {1, 2, 184, "/xml"}
+test_version! {1, 2, 185, "/xml"}
+test_version! {1, 2, 186, "/xml"}
+test_version! {1, 2, 187, "/xml"}
+test_version! {1, 2, 188, "/xml"}
+test_version! {1, 2, 189, "/xml"}
+test_version! {1, 2, 190, "/xml"}
+test_version! {1, 2, 191, "/xml"}
+test_version! {1, 2, 192, "/xml"}
+test_version! {1, 2, 193, "/xml"}
+test_version! {1, 2, 194, "/xml"}
+test_version! {1, 2, 195, "/xml"}
+test_version! {1, 2, 196, "/xml"}
+test_version! {1, 2, 197, "/xml"}
+test_version! {1, 2, 198, "/xml"}
+test_version! {1, 2, 199, "/xml"}
+test_version! {1, 2, 200, "/xml"}
+test_version! {1, 2, 201, "/xml"}
+test_version! {1, 2, 202, "/xml"}
+test_version! {1, 2, 203, "/xml"}
+test_version! {1, 3, 204, "/xml"}
+test_version! {1, 3, 205, "/xml"}
+test_version! {1, 3, 206, "/xml"}
+test_version! {1, 3, 207, "/xml"}
+test_version! {1, 3, 208, "/xml"}
+test_version! {1, 3, 209, "/xml"}
+test_version! {1, 3, 210, "/xml"}
+test_version! {1, 3, 211, "/xml"}
+test_version! {1, 3, 212, "/xml"}
+test_version! {1, 3, 213, "/xml"}
+test_version! {1, 3, 214, "/xml"}
+test_version! {1, 3, 215, "/xml"}
+test_version! {1, 3, 216, "/xml"}
+test_version! {1, 3, 217, "/xml"}
+test_version! {1, 3, 218, "/xml"}
+test_version! {1, 3, 219, "/xml"}
+test_version! {1, 3, 220, "/xml"}
+test_version! {1, 3, 221, "/xml"}
+test_version! {1, 3, 222, "/xml"}
+test_version! {1, 3, 223, "/xml"}
+test_version! {1, 3, 224, "/xml"}
+test_version! {1, 3, 225, "/xml"}

--- a/vk-parse/Cargo.toml
+++ b/vk-parse/Cargo.toml
@@ -16,6 +16,7 @@ vkxml-convert = ["vkxml"]
 
 [dependencies]
 xml-rs = "^0.8"
+bitflags = "^1.3"
 
 vkxml = { optional = true, version = "^0.3" }
 serde = { optional = true, version = "^1.0.75" }

--- a/vk-parse/src/c.rs
+++ b/vk-parse/src/c.rs
@@ -351,12 +351,7 @@ fn is_number_start(c: char) -> bool {
 }
 
 fn is_number_part(c: char) -> bool {
-    c == '.'
-        || c == '+'
-        || c == '-'
-        || c == 'x'
-        || c == 'X'
-        || c.is_ascii_hexdigit()
+    c == '.' || c == '+' || c == '-' || c == 'x' || c == 'X' || c.is_ascii_hexdigit()
 }
 
 fn is_identifier_start(c: char) -> bool {

--- a/vk-parse/src/convert.rs
+++ b/vk-parse/src/convert.rs
@@ -188,14 +188,13 @@ impl From<TypesChild> for Option<vkxml::DefinitionsElement> {
                         }))
                     }
                     TypeSpec::Include { name, quoted } => {
-                        let name = t.name.or(name).unwrap_or_default();
                         let need_ext = !name.ends_with(".h");
                         let include = vkxml::Include {
                             name,
                             notation: t.comment,
                             style: match quoted {
-                                true => vkxml::IncludeStyle::Quote,
-                                false => vkxml::IncludeStyle::Bracket,
+                                Some(true) | None => vkxml::IncludeStyle::Quote,
+                                Some(false) => vkxml::IncludeStyle::Bracket,
                             },
                             need_ext,
                         };
@@ -217,7 +216,7 @@ impl From<TypesChild> for Option<vkxml::DefinitionsElement> {
                             is_disabled,
                             comment,
                             replace,
-                            defref,
+                            defref: defref.into_iter().collect(),
                             parameters: Vec::new(),
                             c_expression: None,
                             value: None,

--- a/vk-parse/src/convert.rs
+++ b/vk-parse/src/convert.rs
@@ -348,11 +348,6 @@ impl From<TypeMember> for vkxml::StructElement {
             TypeMember::Definition(def) => {
                 let mut field: vkxml::Field = def.definition.into();
                 field.type_enums = def.values;
-                for tag in def.markup {
-                    match tag {
-                        TypeMemberMarkup::Comment(comment) => field.notation = Some(comment),
-                    }
-                }
 
                 vkxml::StructElement::Member(field)
             }
@@ -438,6 +433,7 @@ impl From<NameWithType> for vkxml::Field {
             optional,
             noautovalidity,
             objecttype: _,
+            comment,
         } = nt;
         vkxml::Field {
             array: if dynamic_shape.is_some() {
@@ -479,7 +475,7 @@ impl From<NameWithType> for vkxml::Field {
                     .join(","),
             }),
             name: Some(name),
-            notation: None,
+            notation: comment,
             null_terminate: matches!(
                 dynamic_shape,
                 Some(

--- a/vk-parse/src/parse.rs
+++ b/vk-parse/src/parse.rs
@@ -674,7 +674,8 @@ fn parse_name_with_type<
             if let Some(rest) = trimmed_text.strip_prefix(':') {
                 (
                     Some(
-                        rest.parse()
+                        rest.trim_start()
+                            .parse()
                             .expect("after bitfield's ':' only a non-zero integer is expected"),
                     ),
                     None,

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -661,6 +661,108 @@ pub enum Command {
     Definition(Box<CommandDefinition>),
 }
 
+bitflags::bitflags! {
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+    pub struct CommandQueue: u32 {
+        const GRAPHICS = 1 << 0;
+        const COMPUTE = 1 << 1;
+        const TRANSFER = 1 << 2;
+        const SPARSE_BINDING = 1 << 3;
+        const PROTECTED = 1 << 4;
+        const VIDEO_DECODE = 1 << 5;
+        const VIDEO_ENCODE = 1 << 6;
+    }
+}
+
+impl core::fmt::Display for CommandQueue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut prepend_comma = false;
+        if self.contains(CommandQueue::GRAPHICS) {
+            f.write_str("graphics")?;
+            prepend_comma = true;
+        }
+        if self.contains(CommandQueue::COMPUTE) {
+            if prepend_comma {
+                f.write_str(",")?;
+            }
+            f.write_str("compute")?;
+            prepend_comma = true;
+        }
+        if self.contains(CommandQueue::TRANSFER) {
+            if prepend_comma {
+                f.write_str(",")?;
+            }
+            f.write_str("transfer")?;
+            prepend_comma = true;
+        }
+        if self.contains(CommandQueue::SPARSE_BINDING) {
+            if prepend_comma {
+                f.write_str(",")?;
+            }
+            f.write_str("sparse_binding")?;
+            prepend_comma = true;
+        }
+        // this isn't found in the
+        if self.contains(CommandQueue::PROTECTED) {
+            if prepend_comma {
+                f.write_str(",")?;
+            }
+            f.write_str("protected")?;
+            prepend_comma = true;
+        }
+        if self.contains(CommandQueue::VIDEO_DECODE) {
+            if prepend_comma {
+                f.write_str(",")?;
+            }
+            f.write_str("decode")?;
+            prepend_comma = true;
+        }
+        if self.contains(CommandQueue::VIDEO_ENCODE) {
+            if prepend_comma {
+                f.write_str(",")?;
+            }
+            f.write_str("encode")?;
+            // prepend_comma = true;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum CommandSuccessCodes {
+    /// `successcodes="VK_SUCCESS"`
+    DefaultSuccess,
+    Codes(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum CommandRenderpass {
+    Inside,
+    Outside,
+    Both,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum CommandVideoCoding {
+    Inside,
+    Outside,
+    Both,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum CommandBufferLevel {
+    PrimaryOnly,
+    Both,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[non_exhaustive]
@@ -669,43 +771,37 @@ pub struct CommandDefinition {
         feature = "serialize",
         serde(default, skip_serializing_if = "is_default")
     )]
-    pub queues: Option<String>,
+    pub queues: Option<CommandQueue>,
 
     #[cfg_attr(
         feature = "serialize",
         serde(default, skip_serializing_if = "is_default")
     )]
-    pub successcodes: Option<String>,
+    pub successcodes: Option<CommandSuccessCodes>,
 
     #[cfg_attr(
         feature = "serialize",
         serde(default, skip_serializing_if = "is_default")
     )]
-    pub errorcodes: Option<String>,
+    pub errorcodes: Option<Vec<String>>,
 
     #[cfg_attr(
         feature = "serialize",
         serde(default, skip_serializing_if = "is_default")
     )]
-    pub renderpass: Option<String>,
+    pub renderpass: Option<CommandRenderpass>,
 
     #[cfg_attr(
         feature = "serialize",
         serde(default, skip_serializing_if = "is_default")
     )]
-    pub videocoding: Option<String>,
+    pub videocoding: Option<CommandVideoCoding>,
 
     #[cfg_attr(
         feature = "serialize",
         serde(default, skip_serializing_if = "is_default")
     )]
-    pub cmdbufferlevel: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub pipeline: Option<String>,
+    pub cmdbufferlevel: Option<CommandBufferLevel>,
 
     #[cfg_attr(
         feature = "serialize",

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -273,8 +273,8 @@ pub struct Type {
 pub enum TypeSpec {
     None,
     Include {
-        name: Option<String>,
-        quoted: bool,
+        name: String,
+        quoted: Option<bool>,
     },
     Define(TypeDefine),
     Typedef {
@@ -351,12 +351,6 @@ pub struct TypeMemberDefinition {
     )]
     pub limittype: Option<String>,
 
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub code: String,
-
     /// The definition of this member.
     #[cfg_attr(
         feature = "serialize",
@@ -401,7 +395,7 @@ pub enum HandleType {
 pub struct TypeDefine {
     pub name: String,
     pub comment: Option<String>,
-    pub defref: Vec<String>,
+    pub defref: Option<String>,
     pub is_disabled: bool,
     pub replace: bool,
     pub value: TypeDefineValue,
@@ -725,12 +719,6 @@ pub struct CommandDefinition {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub implicitexternsyncparams: Vec<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub code: String,
 }
 
 /// Parameter for this Vulkan function.

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -221,12 +221,6 @@ pub struct Type {
         feature = "serialize",
         serde(default, skip_serializing_if = "is_default")
     )]
-    pub category: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
     pub comment: Option<String>,
 
     #[cfg_attr(
@@ -278,9 +272,22 @@ pub struct Type {
 #[non_exhaustive]
 pub enum TypeSpec {
     None,
-    Code(TypeCode),
-    Members(Vec<TypeMember>),
-    FunctionPointer(NameWithType, Vec<NameWithType>),
+    Include {
+        name: Option<String>,
+        quoted: bool,
+    },
+    Define(TypeDefine),
+    Typedef {
+        name: String,
+        // FIXME doesn't include all of the necessary information to recreate
+        basetype: Option<String>,
+    },
+    Bitmask(Option<NameWithType>),
+    Handle(TypeHandle),
+    Enumeration,
+    FunctionPointer(TypeFunctionPointer),
+    Struct(Vec<TypeMember>),
+    Union(Vec<TypeMember>),
 }
 
 impl Default for TypeSpec {
@@ -289,23 +296,10 @@ impl Default for TypeSpec {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[non_exhaustive]
-pub struct TypeCode {
-    pub code: String,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub markup: Vec<TypeCodeMarkup>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[non_exhaustive]
-pub enum TypeCodeMarkup {
+pub(crate) enum TypeCodeMarkup {
     Name(String),
     Type(String),
     ApiEntry(String),
@@ -418,6 +412,61 @@ pub struct TypeMemberDefinition {
 #[non_exhaustive]
 pub enum TypeMemberMarkup {
     Comment(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct TypeFunctionPointer {
+    pub proto: NameWithType,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub params: Vec<NameWithType>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct TypeHandle {
+    pub name: String,
+
+    pub handle_type: HandleType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum HandleType {
+    Dispatch,
+    NoDispatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct TypeDefine {
+    pub name: String,
+    pub comment: Option<String>,
+    pub defref: Vec<String>,
+    pub is_disabled: bool,
+    pub replace: bool,
+    pub value: TypeDefineValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum TypeDefineValue {
+    Empty,
+    Value(String),
+    Expression(String),
+    Function {
+        params: Vec<String>,
+        expression: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -185,7 +185,7 @@ pub type Types = CommentedChildren<TypesChild>;
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum TypesChild {
-    Type(Type),
+    Type(Box<Type>),
     Comment(String),
 }
 
@@ -314,7 +314,7 @@ pub enum TypeMember {
     Comment(String),
 
     /// A structure field definition.
-    Definition(TypeMemberDefinition),
+    Definition(Box<TypeMemberDefinition>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -641,7 +641,7 @@ pub enum Command {
     Alias { name: String, alias: String },
 
     /// Defines a new Vulkan function.
-    Definition(CommandDefinition),
+    Definition(Box<CommandDefinition>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -832,6 +832,16 @@ pub enum CommandBufferLevel {
     Both,
 }
 
+bitflags::bitflags! {
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+    pub struct CommandTask: u32 {
+        const ACTION = 1 << 0;
+        const STATE = 1 << 1;
+        const SYNCHRONIZATION = 1 << 2;
+        const INDIRECTION = 1 << 3;
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[non_exhaustive]
@@ -907,6 +917,12 @@ pub struct CommandDefinition {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub implicitexternsyncparams: Vec<String>,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub tasks: Option<CommandTask>,
 }
 
 /// Parameter for this Vulkan function.

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -363,19 +363,6 @@ pub struct TypeMemberDefinition {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub definition: NameWithType,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub markup: Vec<TypeMemberMarkup>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
-#[non_exhaustive]
-pub enum TypeMemberMarkup {
-    Comment(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -1239,6 +1226,12 @@ pub struct NameWithType {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub objecttype: Option<String>,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub comment: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -325,30 +325,6 @@ pub struct TypeMemberDefinition {
         feature = "serialize",
         serde(default, skip_serializing_if = "is_default")
     )]
-    pub len: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub altlen: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub externsync: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub optional: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
     pub selector: Option<String>,
 
     #[cfg_attr(
@@ -356,12 +332,6 @@ pub struct TypeMemberDefinition {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub selection: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub noautovalidity: Option<String>,
 
     #[cfg_attr(
         feature = "serialize",
@@ -380,12 +350,6 @@ pub struct TypeMemberDefinition {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub limittype: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub objecttype: Option<String>,
 
     #[cfg_attr(
         feature = "serialize",
@@ -787,47 +751,6 @@ pub struct CommandDefinition {
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub struct CommandParam {
-    /// The expression which indicates the length of this array.
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub len: Option<String>,
-
-    /// Alternate description of the length of this parameter.
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub altlen: Option<String>,
-
-    /// Whether this parameter must be externally synchronised by the app.
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub externsync: Option<String>,
-
-    /// Whether this parameter must have a non-null value.
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub optional: Option<String>,
-
-    /// Disables automatic validity language being generated for this item.
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub noautovalidity: Option<String>,
-
-    #[cfg_attr(
-        feature = "serialize",
-        serde(default, skip_serializing_if = "is_default")
-    )]
-    pub objecttype: Option<String>,
-
     /// The definition of this parameter.
     #[cfg_attr(
         feature = "serialize",
@@ -1199,9 +1122,48 @@ pub enum PointerKind {
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum ArrayLength {
-    // TODO could probably make this smaller and/or NonZero
-    Static(usize),
+    Static(core::num::NonZeroUsize),
     Constant(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum DynamicLength {
+    NullTerminated,
+    // FIXME only found in VkAccelerationStructureBuildGeometryInfoKHR->ppGeometries, is this a mistake?
+    Static(core::num::NonZeroUsize),
+    Parameterized(String),
+    ParameterizedField { parameter: String, field: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum DynamicShapeKind {
+    Expression {
+        latex_expr: Option<String>,
+        c_expr: String,
+    },
+    Single(DynamicLength),
+    Double(DynamicLength, DynamicLength),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum OptionalKind {
+    Single(bool),
+    Double(bool, bool),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum ExternSyncKind {
+    /// externsync="true"
+    Value,
+    Fields(Vec<String>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -1243,6 +1205,40 @@ pub struct NameWithType {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub name: String,
+
+    /// combination of `len` and `altlen` attributes
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub dynamic_shape: Option<DynamicShapeKind>,
+
+    /// Whether this parameter must be externally synchronised by the app.
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub externsync: Option<ExternSyncKind>,
+
+    /// Whether this parameter must have a non-null value.
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub optional: Option<OptionalKind>,
+
+    /// Disables automatic validity language being generated for this item.
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub noautovalidity: Option<()>,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub objecttype: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]


### PR DESCRIPTION
Major work-in-progress, but the goal is to parse everything (attributes and text) into strongly-typed data structures where the only strings left are names & comments. A goal is to make it so no downstream crate will need to parse any C expressions/types/defines. Also I wanted to ensure no information was lost.

- [ ] Bike-shedding of all of the new types
- [ ] Actual error-handling and not just panicking with my unhelpful messages
- [ ] Possibly remove backward-compat workarounds
- [ ] Possibly handle parsing the platform-specific typedef edge-case code that uses Objective-C
- [ ] Need to rebase/merge
- [ ] Remove extraneous clippy fixes
- [ ] Move to using nom for the string parsing if it's ok to add as a dependency

I started working on this as I needed more information for extending the ash code-gen for formats, and neither vk-parse or vkxml include what I needed. I'm creating this early pull request to get some feedback on naming, backwards compatibility policy, and the usage of nom.