### PR TITLE
Support `api` attribute since Vulkan 1.3.241

### DIFF
--- a/vk-parse/src/parse.rs
+++ b/vk-parse/src/parse.rs
@@ -463,6 +463,7 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
     let mut objtypeenum = None;
     let mut bitvalues = None;
     let mut comment = None;
+    let mut deprecated = None;
 
     let mut code = String::new();
     let mut markup = Vec::new();
@@ -480,7 +481,8 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
         "allowduplicate" => allowduplicate = Some(a.value),
         "objtypeenum"    => objtypeenum    = Some(a.value),
         "bitvalues"      => bitvalues      = Some(a.value),
-        "comment"        => comment        = Some(a.value)
+        "comment"        => comment        = Some(a.value),
+        "deprecated"     => deprecated     = Some(a.value),
     }
 
     match_elements_combine_text! {ctx, attributes, code,
@@ -496,6 +498,7 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
             let mut values = None;
             let mut limittype = None;
             let mut objecttype = None;
+            let mut deprecated = None;
             let mut code = String::new();
             let mut markup = Vec::new();
             match_attributes!{ctx, a in attributes,
@@ -509,7 +512,8 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
                 "validextensionstructs" => validextensionstructs = Some(a.value),
                 "values"                => values                = Some(a.value),
                 "limittype"             => limittype             = Some(a.value),
-                "objecttype"            => objecttype            = Some(a.value)
+                "objecttype"            => objecttype            = Some(a.value),
+                "deprecated"            => deprecated            = Some(a.value),
             }
             match_elements_combine_text!{ctx, code,
                 "type" => {
@@ -546,6 +550,7 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
                 objecttype,
                 code,
                 markup,
+                deprecated,
             }))
         },
         "comment" => members.push(TypeMember::Comment(parse_text_element(ctx))),
@@ -579,6 +584,7 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
         objtypeenum,
         bitvalues,
         comment,
+        deprecated,
         spec: if members.len() > 0 {
             TypeSpec::Members(members)
         } else if code.len() > 0 {
@@ -773,6 +779,7 @@ fn parse_enum<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
     let mut positive = true;
     let mut protect = None;
     let mut alias = None;
+    let mut deprecated = None;
 
     match_attributes! {ctx, a in attributes,
         "name" => name = Some(a.value),
@@ -796,7 +803,8 @@ fn parse_enum<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
         "bitpos" => bitpos = Some(a.value),
         "extnumber" => extnumber = Some(a.value),
         "protect" => protect = Some(a.value),
-        "alias" => alias = Some(a.value)
+        "alias" => alias = Some(a.value),
+        "deprecated" => deprecated = Some(a.value),
     }
 
     unwrap_attribute!(ctx, enum, name);
@@ -878,6 +886,7 @@ fn parse_enum<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
         api,
         protect,
         spec,
+        deprecated,
     })
 }
 

--- a/vk-parse/src/parse.rs
+++ b/vk-parse/src/parse.rs
@@ -499,6 +499,7 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
             let mut limittype = None;
             let mut objecttype = None;
             let mut deprecated = None;
+            let mut api = None;
             let mut code = String::new();
             let mut markup = Vec::new();
             match_attributes!{ctx, a in attributes,
@@ -514,6 +515,7 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
                 "limittype"             => limittype             = Some(a.value),
                 "objecttype"            => objecttype            = Some(a.value),
                 "deprecated"            => deprecated            = Some(a.value),
+                "api"                   => api                   = Some(a.value),
             }
             match_elements_combine_text!{ctx, code,
                 "type" => {
@@ -551,6 +553,7 @@ fn parse_type<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) -> 
                 code,
                 markup,
                 deprecated,
+                api,
             }))
         },
         "comment" => members.push(TypeMember::Comment(parse_text_element(ctx))),
@@ -607,6 +610,7 @@ fn parse_command<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) 
     let mut cmdbufferlevel = None;
     let mut pipeline = None;
     let mut comment = None;
+    let mut api = None;
 
     match_attributes! {ctx, a in attributes,
         "name" => name = Some(a.value),
@@ -619,7 +623,8 @@ fn parse_command<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) 
         "videocoding" => videocoding = Some(a.value),
         "cmdbufferlevel" => cmdbufferlevel = Some(a.value),
         "pipeline" => pipeline = Some(a.value),
-        "comment" => comment = Some(a.value)
+        "comment" => comment = Some(a.value),
+        "api" => api = Some(a.value),
     }
 
     if let Some(alias) = alias {
@@ -685,6 +690,7 @@ fn parse_command<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) 
                 let mut objecttype = None;
                 let mut validstructs = None;
                 let mut stride = None;
+                let mut api = None;
 
                 match_attributes!{ctx, a in attributes,
                     "len"            => len            = Some(a.value),
@@ -695,6 +701,7 @@ fn parse_command<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) 
                     "objecttype"     => objecttype     = Some(a.value),
                     "validstructs"   => validstructs   = Some(a.value),
                     "stride"         => stride         = Some(a.value),
+                    "api"            => api            = Some(a.value),
                 }
 
                 let validstructs = validstructs.map_or(
@@ -715,7 +722,8 @@ fn parse_command<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) 
                         objecttype,
                         definition,
                         validstructs,
-                        stride
+                        stride,
+                        api,
                     });
                 }
             },
@@ -762,6 +770,7 @@ fn parse_command<R: Read>(ctx: &mut ParseCtx<R>, attributes: Vec<XmlAttribute>) 
             description,
             implicitexternsyncparams,
             code,
+            api,
         }))
     }
 }

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -412,6 +412,12 @@ pub struct TypeMemberDefinition {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub deprecated: Option<String>,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub api: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -747,6 +753,12 @@ pub struct CommandDefinition {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub code: String,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub api: Option<String>,
 }
 
 /// Parameter for this Vulkan function.
@@ -817,6 +829,12 @@ pub struct CommandParam {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub stride: Option<String>,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub api: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -267,6 +267,12 @@ pub struct Type {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub spec: TypeSpec,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub deprecated: Option<String>,
 }
 
 /// The contents of a type definition.
@@ -400,6 +406,12 @@ pub struct TypeMemberDefinition {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub markup: Vec<TypeMemberMarkup>,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub deprecated: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -548,6 +560,12 @@ pub struct Enum {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub spec: EnumSpec,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub deprecated: Option<String>,
 }
 
 /// An enum specifier, which assigns a value to the enum.


### PR DESCRIPTION
Depends on #28

This new attribute is added to tell Vulkan and Vulkan SC bindings apart.

