### PR TITLE
Support new `depends` property since Vulkan 1.3.241

### DIFF
--- a/vk-parse/src/parse.rs
+++ b/vk-parse/src/parse.rs
@@ -989,6 +989,7 @@ fn parse_extension<R: Read>(
     let mut provisional = None;
     let mut specialuse = None;
     let mut sortorder = None;
+    let mut depends = None;
     let mut children = Vec::new();
 
     match_attributes! {ctx, a in attributes,
@@ -1008,7 +1009,8 @@ fn parse_extension<R: Read>(
         "provisional"  => provisional   = Some(a.value),
         "obsoletedby"  => obsoletedby   = Some(a.value),
         "specialuse"   => specialuse    = Some(a.value),
-        "sortorder"    => sortorder     = Some(a.value)
+        "sortorder"    => sortorder     = Some(a.value),
+        "depends"      => depends       = Some(a.value),
     }
 
     let number = match number {
@@ -1062,6 +1064,7 @@ fn parse_extension<R: Read>(
         specialuse,
         sortorder,
         children,
+        depends,
     })
 }
 
@@ -1074,6 +1077,7 @@ fn parse_extension_item_require<R: Read>(
     let mut extension = None;
     let mut feature = None;
     let mut comment = None;
+    let mut depends = None;
     let mut items = Vec::new();
 
     match_attributes! {ctx, a in attributes,
@@ -1081,7 +1085,8 @@ fn parse_extension_item_require<R: Read>(
         "profile"   => profile   = Some(a.value),
         "extension" => extension = Some(a.value),
         "feature"   => feature   = Some(a.value),
-        "comment"   => comment   = Some(a.value)
+        "comment"   => comment   = Some(a.value),
+        "depends"   => depends   = Some(a.value),
     }
 
     while let Some(Ok(e)) = ctx.events.next() {
@@ -1110,6 +1115,7 @@ fn parse_extension_item_require<R: Read>(
         feature,
         comment,
         items,
+        depends,
     }
 }
 

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -965,6 +965,12 @@ pub struct Extension {
         serde(default, skip_serializing_if = "is_default")
     )]
     pub children: Vec<ExtensionChild>,
+
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "is_default")
+    )]
+    pub depends: Option<String>,
 }
 
 /// A part of an extension declaration.
@@ -1009,6 +1015,12 @@ pub enum ExtensionChild {
 
         /// The items which form this require block.
         items: Vec<InterfaceItem>,
+
+        #[cfg_attr(
+            feature = "serialize",
+            serde(default, skip_serializing_if = "is_default")
+        )]
+        depends: Option<String>,
     },
 
     /// Indicates the items this extension removes.


### PR DESCRIPTION
`depends` is a new way of communicating Vulkan core and extension requirements for extensions, using a special format that combines AND and OR operators.
