### PR TITLE
Parsing unexpected elements

### DIFF
--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -13,3 +13,6 @@ serde_derive = "^1.0.77"
 vk-parse = { path = "../vk-parse", features = ["serialize", "vkxml-convert"] }
 vkxml = "^0.3"
 xml-rs = "^0.8"
+
+[features]
+openxr = []

--- a/ci/src/openxr.rs
+++ b/ci/src/openxr.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "openxr")]
+use crate::{
+    TestApi,
+    parsing_test,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct OpenXR;
+
+impl TestApi for OpenXR {
+    const MAIN_URL: Option<&'static str> = None;
+    const ALLOW_WARNINGS: bool = true;
+    const USE_VKXML: bool = false;
+    fn download_url(major: u32, minor: u32, patch: u32, _url_suffix: &str) -> String {
+        format!(
+            "https://github.com/KhronosGroup/OpenXR-SDK-Source/raw/release-{}.{}.{}/specification/registry/xr.xml",
+            major, minor, patch
+        )
+    }
+}
+
+macro_rules! test_xr_versions {
+    ($($test_name:ident($major:expr, $minor:expr, $patch:expr)),+ $(,)?) => {
+        $(
+            #[test]
+            fn $test_name() {
+                parsing_test::<OpenXR>($major, $minor, $patch, "");
+            }
+        )+
+    };
+}
+
+test_xr_versions! {
+    xr_test_v1_0_33(1, 0, 33),
+    xr_test_v1_0_34(1, 0, 34),
+}

--- a/vk-parse/examples/parse.rs
+++ b/vk-parse/examples/parse.rs
@@ -1,0 +1,34 @@
+use std::{
+    error::Error,
+    path::PathBuf,
+    fmt,
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let path = std::env::args()
+        .skip(1)
+        .map(PathBuf::from)
+        .next()
+        .ok_or(MissingArgumentError("XML_PATH"))?;
+    let registry = vk_parse::parse_file(path.as_ref())
+        .map(|(ret, errors)| {
+            errors.into_iter().for_each(|e| {
+                eprintln!("non-fatal error while parsing registry: {:?}", &e);
+            });
+            ret
+        });
+    println!("{:#?}", &registry);
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+struct MissingArgumentError<'a>(&'a str);
+
+impl<'a> fmt::Display for MissingArgumentError<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "missing required argument: {}", self.0)
+    }
+}
+
+impl<'a> Error for MissingArgumentError<'a> {}


### PR DESCRIPTION
Previously, if things that utilized this separated match pattern would fail if encountering any unexpected/unknown elements.

EX. when parsing the OpenXR spec, `require` can contain `interaction_profile` elements, which causes `parse_interface_item` to return None (as an error case), and the rest of the block is never processed.

I introduced an alternative pattern to `unwrap_attribute!` in `parse_attributes!` that allowggs to acheive a simliar pattern, without the early return being *in the macro*, allowing the invoker to regain control of the control flow.

This allowed moving all invocations of `parse_interface_item` to more standard `parse_*` function patterns used elsewhere, allowing it to function simliarly and properly handle unexpected elements.

With this patch, the `1.0.33` [OpenXR](https://github.com/KhronosGroup/OpenXR-Registry) specification parses, with the expected non-fatal errors of unrecognized elements that are unique to OpenXR and not Vulkan.