### PR TITLE
convert: Parse constant values from `<enums type="constants">` element

### DIFF
--- a/vk-parse/src/convert.rs
+++ b/vk-parse/src/convert.rs
@@ -92,8 +92,8 @@ impl From<Registry> for vkxml::Registry {
                         .push(vkxml::RegistryElement::Definitions(types.into()));
                 }
 
-                RegistryChild::Enums(e) => match e.kind {
-                    None => {
+                RegistryChild::Enums(e) => match e.kind.as_deref() {
+                    None | Some("constants") => {
                         flush_enums(&mut enums, &mut registry.elements);
                         let mut constants = vkxml::Constants {
                             notation: e.comment,
@@ -112,7 +112,7 @@ impl From<Registry> for vkxml::Registry {
                         let enumeration = vkxml::Enumeration {
                             name: e.name.unwrap_or(String::new()),
                             notation: e.comment,
-                            purpose: if kind.as_str() == "bitmask" {
+                            purpose: if kind == "bitmask" {
                                 Some(vkxml::EnumerationPurpose::Bitmask)
                             } else {
                                 None


### PR DESCRIPTION
Upstream Vulkan is making a change to annotate the `<enums>` element containing constant values with a new `type="constants"` "kind", rather than leaving it untyped.  This change also involves making the `type` attribute a required attribute, but `vk-parse` cannot remove the `Option`ality of it to not break parsing of older `vk.xml` files.

See https://togithub.com/KhronosGroup/Vulkan-Docs/pull/2366.
