### PR TITLE
Parse `<feature>` element inside interface items

### DIFF
--- a/vk-parse/src/convert.rs
+++ b/vk-parse/src/convert.rs
@@ -1006,6 +1006,7 @@ impl From<ExtensionChild> for vkxml::ExtensionElement {
                 api,
                 profile,
                 comment,
+                reasonlink: _,
                 items,
             } => vkxml::ExtensionElement::Remove(vkxml::ExtensionSpecification {
                 profile,

--- a/vk-parse/src/convert.rs
+++ b/vk-parse/src/convert.rs
@@ -1046,16 +1046,16 @@ impl From<ExtensionChild> for Option<vkxml::FeatureSpecification> {
                 profile,
                 notation: comment,
                 extension,
-                elements: items.into_iter().map(|i| i.into()).collect(),
+                elements: items.into_iter().filter_map(|i| i.into()).collect(),
             }),
             ExtensionChild::Remove { .. } => None,
         }
     }
 }
 
-impl From<InterfaceItem> for vkxml::FeatureReference {
+impl From<InterfaceItem> for Option<vkxml::FeatureReference> {
     fn from(orig: InterfaceItem) -> Self {
-        match orig {
+        Some(match orig {
             InterfaceItem::Comment(v) => vkxml::FeatureReference::Notation(v),
             InterfaceItem::Type { name, comment } => {
                 vkxml::FeatureReference::DefinitionReference(vkxml::NamedIdentifier {
@@ -1075,7 +1075,8 @@ impl From<InterfaceItem> for vkxml::FeatureReference {
                     notation: comment,
                 })
             }
-        }
+            InterfaceItem::Feature { .. } => return None,
+        })
     }
 }
 
@@ -1205,6 +1206,8 @@ impl From<InterfaceItem> for Option<vkxml::ExtensionSpecificationElement> {
                     notation: comment,
                 }),
             ),
+
+            InterfaceItem::Feature { .. } => None,
         }
     }
 }

--- a/vk-parse/src/parse.rs
+++ b/vk-parse/src/parse.rs
@@ -1165,12 +1165,14 @@ fn parse_extension_item_remove<R: Read>(
     let mut api = None;
     let mut profile = None;
     let mut comment = None;
+    let mut reasonlink = None;
     let mut items = Vec::new();
 
     match_attributes! {ctx, a in attributes,
-        "api"     => api     = Some(a.value),
-        "profile" => profile = Some(a.value),
-        "comment" => comment = Some(a.value)
+        "api"        => api        = Some(a.value),
+        "profile"    => profile    = Some(a.value),
+        "comment"    => comment    = Some(a.value),
+        "reasonlink" => reasonlink = Some(a.value),
     }
 
     while let Some(Ok(e)) = ctx.events.next() {
@@ -1196,6 +1198,7 @@ fn parse_extension_item_remove<R: Read>(
         api,
         profile,
         comment,
+        reasonlink,
         items,
     }
 }

--- a/vk-parse/src/parse.rs
+++ b/vk-parse/src/parse.rs
@@ -1230,6 +1230,24 @@ fn parse_interface_item<R: Read>(
             consume_current_element(ctx);
             Some(InterfaceItem::Command { name, comment })
         }
+        "feature" => {
+            let mut name = None;
+            let mut struct_ = None;
+            let mut comment = None;
+            match_attributes! {ctx, a in attributes,
+                "name"    => name    = Some(a.value),
+                "struct"  => struct_ = Some(a.value),
+                "comment" => comment = Some(a.value)
+            }
+            unwrap_attribute!(ctx, type, name);
+            unwrap_attribute!(ctx, type, struct_);
+            consume_current_element(ctx);
+            Some(InterfaceItem::Feature {
+                name,
+                struct_,
+                comment,
+            })
+        }
         _ => {
             ctx.errors.push(Error::UnexpectedElement {
                 xpath: ctx.xpath.clone(),

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -1133,6 +1133,18 @@ pub enum InterfaceItem {
         )]
         comment: Option<String>,
     },
+
+    Feature {
+        name: String,
+
+        struct_: String,
+
+        #[cfg_attr(
+            feature = "serialize",
+            serde(default, skip_serializing_if = "is_default")
+        )]
+        comment: Option<String>,
+    },
 }
 
 pub type Formats = CommentedChildren<Format>;

--- a/vk-parse/src/types.rs
+++ b/vk-parse/src/types.rs
@@ -1099,6 +1099,12 @@ pub enum ExtensionChild {
             feature = "serialize",
             serde(default, skip_serializing_if = "is_default")
         )]
+        reasonlink: Option<String>,
+
+        #[cfg_attr(
+            feature = "serialize",
+            serde(default, skip_serializing_if = "is_default")
+        )]
         items: Vec<InterfaceItem>,
     },
 }


### PR DESCRIPTION
Vulkan `1.3.294` added a new `<feature name="x" struct="y">` element to `<require>` and `<remove>` to define which flag in a feature struct needs to be turned on to use a certain subset of API defined inside an extension or Vulkan feature API (where the subset is grouped by the `<require>` element).

https://github.com/KhronosGroup/Vulkan-Docs/commit/fb9f45c5ee8f4e8cd6f2b19eeb751fd305773a67#diff-a53ddc6f1c14c9bd4dad7279a1866ffc4f9f3141fd30212d5f1faf4c2b12c284
https://github.com/KhronosGroup/Vulkan-Headers/pull/498
