### PR TITLE
convert: Parse bitfield size in struct members

### DIFF
--- a/vk-parse/src/convert.rs
+++ b/vk-parse/src/convert.rs
@@ -852,6 +852,11 @@ fn parse_c_field<'a, I: Iterator<Item = &'a str>>(
             "]" => {
                 break;
             }
+            ":" => {
+                iter.next().unwrap();
+                let _bitfield_size: usize = iter.peek().unwrap().parse().unwrap();
+                dbg!(_bitfield_size);
+            }
             t => {
                 if r.array.is_some() {
                     let mut is_number = true;


### PR DESCRIPTION
Vulkan has always had a bunch of `<member>`s which are bit fields with a defined size after a colon, C/C++ syntax.  The conversion to `vkxml` never handled these, resulting in the parser to treat this final numeric token as the field name.

In some ways that's desired, as `vkxml` does not have a field to represent bitfield sizes and the crate cannot be updated (we should really stop using it in `ash`...).  Having a "broken" numeric in the field name like this at least communicates that this data cannot be trusted/used, and on the `ash` side we've always manually redefined structs with bitfields.
